### PR TITLE
Use semver logic to filter and sort repository tags

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -22,7 +22,7 @@ prepare_repository "$destination" "$payload"
 
 # return latest tag on this branch
 branch=$(jq -r '.source.branch // ""' < "$payload")
-tags=$(git tag --merged "$branch" -l --sort=version:refname "$pre[0-9]*" 2>/dev/null)
+tags=$(sorted_tags $branch)
 
 if [ -z "$tags" ]; then
   initial_version=$(jq -r '.source.initial_version // "0.0.0"' < "$payload")

--- a/assets/check
+++ b/assets/check
@@ -22,7 +22,7 @@ prepare_repository "$destination" "$payload"
 
 # return latest tag on this branch
 branch=$(jq -r '.source.branch // ""' < "$payload")
-tags=$(git tag --merged "$branch" -l --sort=version:refname "*" 2>/dev/null)
+tags=$(git tag --merged "$branch" -l --sort=version:refname "$pre[0-9]*" 2>/dev/null)
 
 if [ -z "$tags" ]; then
   initial_version=$(jq -r '.source.initial_version // "0.0.0"' < "$payload")

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -87,6 +87,18 @@ prepare_repository() {
   git reset --hard FETCH_HEAD
 }
 
+sorted_tags() {
+  # return only those tags that are recognised by semver as versions
+  local branch="$1"
+  NODE_PATH=/usr/lib/node_modules node -e '
+  var semver=require("semver");
+  var versions=process.argv.slice(1);
+  versions.filter(semver.valid)
+      .sort(function(a, b) {return semver.compare(a, b);})
+      .forEach(function(x) {console.log(x)});
+  ' $(git tag --merged "$branch" -l "*" 2>/dev/null)
+}
+
 bump_version() {
   local version="$1"
   local payload="$2"

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -91,9 +91,9 @@ sorted_tags() {
   # return only those tags that are recognised by semver as versions
   local branch="$1"
   NODE_PATH=/usr/lib/node_modules node -e '
-  var semver=require("semver");
-  var versions=process.argv.slice(1);
-  versions.filter(semver.valid)
+    var semver=require("semver");
+    var versions=process.argv.slice(1);
+    versions.filter(semver.valid)
       .sort(function(a, b) {return semver.compare(a, b);})
       .forEach(function(x) {console.log(x)});
   ' $(git tag --merged "$branch" -l "*" 2>/dev/null)

--- a/assets/out
+++ b/assets/out
@@ -40,7 +40,7 @@ if [ -n "$version_file" ]; then
 else
   # return latest tag on this branch
   branch=$(jq -r '.source.branch // ""' < "$payload")
-  latest_tag=$(git tag --merged "$branch" -l --sort=version:refname "*" 2>/dev/null | tail -1)
+  latest_tag=$(sorted_tags $branch | tail -1)
   log "Latest tag is $latest_tag"
 
   # use initial version if there aren't any tags yet


### PR DESCRIPTION
Version tagging runs into a problem on repositories that contain tags other than version tags. This patch uses a node.js one-liner to filter the tags down to those that are valid version strings, and sort them using semver's own logic.